### PR TITLE
allow challenge selection

### DIFF
--- a/app/main/index.js
+++ b/app/main/index.js
@@ -40,7 +40,7 @@ if (isRunning) {
 function allowedUrl(url) {
   const urls = [
     'https://accounts.google.com/@(u|AccountChooser|AddSession|ServiceLogin|CheckCookie|Logout){**/**,**}',
-    'https://accounts.google.com/signin/@(usernamerecovery|recovery|challenge){**/**,**}',
+    'https://accounts.google.com/signin/@(usernamerecovery|recovery|challenge|selectchallenge){**/**,**}',
     'http://www.google.*/accounts/Logout2**',
     'https://inbox.google.com{**/**,**}',
     'https://{accounts.youtube,inbox.google}.com/accounts/@(SetOSID|SetSID)**',


### PR DESCRIPTION
This change allows the selection of a different two-factor challenge. It is e.g. required when using a Yubikey which does not work within electron and it is therefore necessary to select another second factor.