### PR TITLE
Fix typo: 'Shoozed' -> 'Snoozed'

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Inboxer supports all Inbox by Gmail keyboard shortcuts, system-specific keybindi
 | Compose Message              | <kbd>Cmd/Ctrl</kbd> <kbd>N</kbd>
 | Create Reminder              | <kbd>Cmd/Ctrl</kbd> <kbd>Shift</kbd> <kbd>N</kbd>
 | Go to Inbox                  | <kbd>Cmd/Ctrl</kbd> <kbd>I</kbd>
-| Go to Shoozed                | <kbd>Cmd/Ctrl</kbd> <kbd>S</kbd>
+| Go to Snoozed                | <kbd>Cmd/Ctrl</kbd> <kbd>S</kbd>
 | Go to Done                   | <kbd>Cmd/Ctrl</kbd> <kbd>D</kbd>
 | Drafts                       | <kbd>Cmd/Ctrl</kbd> <kbd>Shift</kbd> <kbd>D</kbd>
 | Sent                         | <kbd>Cmd/Ctrl</kbd> <kbd>Shift</kbd> <kbd>S</kbd>

--- a/app/main/menu.js
+++ b/app/main/menu.js
@@ -101,7 +101,7 @@ const viewItems = [
     label: 'Go to Snoozed',
     accelerator: 'CmdOrCtrl+S',
     click(menuItem, focusedWindow) {
-      sendAction(focusedWindow, 'go-to-shoozed');
+      sendAction(focusedWindow, 'go-to-snoozed');
     },
   },
   {

--- a/app/main/tray.js
+++ b/app/main/tray.js
@@ -22,9 +22,9 @@ const contextMenu = focusedWindow => [
     },
   },
   {
-    label: 'Go to Shoozed',
+    label: 'Go to Snoozed',
     click() {
-      sendAction(focusedWindow, 'go-to-shoozed');
+      sendAction(focusedWindow, 'go-to-snoozed');
     },
   },
   {

--- a/app/renderer/browser.js
+++ b/app/renderer/browser.js
@@ -9,7 +9,7 @@ ipc.on('show-preferences', () => $('.oin9Fc.cQ.lN').click());
 // primary folder shortcuts
 
 ipc.on('go-to-inbox', () => $$('.pa .oin9Fc.cN')[0].click());
-ipc.on('go-to-shoozed', () => $$('.pa .oin9Fc.cN')[1].click());
+ipc.on('go-to-snoozed', () => $$('.pa .oin9Fc.cN')[1].click());
 ipc.on('go-to-done', () => $$('.pa .oin9Fc.cN')[2].click());
 
 // secondary folder shortcuts


### PR DESCRIPTION
Was visible in README and system tray menu, and also present in code.