### PR TITLE
Fix position of notification and avatar icons

### DIFF
--- a/app/renderer/browser.css
+++ b/app/renderer/browser.css
@@ -202,7 +202,8 @@ body {
 .gb_Df,
 .gb_Df>.gb_R,
 .gb_Ef>.gb_R,
-.gb_Ff>.gb_R {
+.gb_Ff>.gb_R,
+.gb_Mf>.gb_R {
   height: 40px !important;
 }
 


### PR DESCRIPTION
This fixes the position offset of the notification and avatar icons.

Before the fix:
<img width="255" alt="screen shot 2018-03-24 at 12 15 29" src="https://user-images.githubusercontent.com/10482293/37860316-7cfd5186-2f5d-11e8-9fb8-bec5665146f4.png">

After the fix:
<img width="244" alt="screen shot 2018-03-24 at 12 16 35" src="https://user-images.githubusercontent.com/10482293/37860317-7d56921e-2f5d-11e8-9bd6-aedd06b05b25.png">
