### PR TITLE
display tooltip with URL when hovering over link

### DIFF
--- a/app/renderer/browser.css
+++ b/app/renderer/browser.css
@@ -348,3 +348,27 @@ a.gb_b.gb_eb.gb_R::before {
   right: -8px;
   bottom: -8px;
 }
+
+/* Tooltip to display link contents */
+/* <div class="tE"> contains message view area (right side of window) */
+div.tE a[href]::after {
+    content: attr(href);
+    position: absolute;
+    display: table;
+    left: 50%;
+    bottom: 100%;
+    transform: translateX(-50%) translateY(-10%);
+    background: rgba(0,0,0,0.7);
+    text-align: center;
+    color: #fff;
+    font: normal small sans-serif;
+    border-radius: 5px;
+    pointer-events: none;
+    padding: 4px 8px;
+    z-index:99;
+    opacity:0;
+}
+
+div.tE a[href]:hover::after {
+   opacity:1
+}


### PR DESCRIPTION
I know that google is discontinuing Inbox and the future of this project is uncertain at this point. However, I am still using it daily and plan to use it until it for a while longer (google allowing).

About this feature: when an email contains a link of any kind, hovering the mouse over it will display the URL of the link.
This feature seems very useful from a security standpoint and it can be fully implemented in CSS. I thought it'd be worth adding even if interest in development has stopped.

NOTE: the implementation is not perfect. If the link is close to one of the edges the contents of the tooltip will be clipped.