### PR TITLE
fix duplicate new email notifications 

### DIFF
--- a/app/renderer/unreads.js
+++ b/app/renderer/unreads.js
@@ -7,7 +7,7 @@ const seenMessages = new Map();
 
 function keyByMessage({ subject, sender, avatar }) {
   try {
-    return JSON.stringify({ subject, sender, avatar });
+    return JSON.stringify({ subject, sender });
   } catch (error) {
     console.error(error); // eslint-disable-line
     return undefined;

--- a/app/renderer/unreads.js
+++ b/app/renderer/unreads.js
@@ -5,7 +5,7 @@ const { ipcRenderer: ipc } = require('electron');
 
 const seenMessages = new Map();
 
-function keyByMessage({ subject, sender, avatar }) {
+function keyByMessage({ subject, sender }) {
   try {
     return JSON.stringify({ subject, sender });
   } catch (error) {


### PR DESCRIPTION
This fixes issue #64.
I'm running Inboxer on Linux and I routinely get two notifications when I get a new email. This happens quite frequently although not always. 

The cause of the double notification is a change in the avatar picture a few seconds after the arrival of the new email. The new email arrival correctly generates one notification. Then the avatar changes. Now it looks as if a different email is in the "unread" list and another notification is generated.

This is solved by not using the avatar to identify emails. Not sure if this is the right approach but it works.