### PR TITLE
force main window to display on notification click

### DIFF
--- a/app/main/index.js
+++ b/app/main/index.js
@@ -199,3 +199,7 @@ ipcMain.on('update-unreads-count', (e, unreadCount) => {
 ipcMain.on('update-overlay-icon', (e, image, count) => {
   mainWindow.setOverlayIcon(nativeImage.createFromDataURL(image), count);
 });
+
+ipcMain.on('show-window', () => {
+  mainWindow.show();
+});

--- a/app/renderer/unreads.js
+++ b/app/renderer/unreads.js
@@ -85,6 +85,7 @@ function checkUnreads(period = 2000) {
         body: subject,
         icon: avatar,
       }).addEventListener('click', () => {
+        ipc.send('show-window', true);
         sendClick(element);
       });
     }


### PR DESCRIPTION
Currently, clicking a "New Email" notification propagates the click to the newly received message, which opens the message in the main window. However, the click does not force the Inboxer window to be displayed. If the window was minimized or hidden, the user may not notice the effects of the click until the next time the Inboxer window is shown. I personally find this quite confusing.

The changes in this PR force the window to be shown together with the click propagation. A click on the "new email" notification displays the Inboxer window and opens the message.