### PR TITLE
Clean seenMessages variable as new messages are read

### DIFF
--- a/app/renderer/unreads.js
+++ b/app/renderer/unreads.js
@@ -68,18 +68,20 @@ function getUnreadMessages() {
 }
 
 function checkUnreads(period = 2000) {
+  if ( typeof checkUnreads.startingUp == 'undefined' ) {
+    checkUnreads.startingUp = true;
+  }
+
   const unreads = getUnreadMessages();
 
   ipc.send('update-unreads-count', unreads.length);
-
-  const startingUp = seenMessages.size === 0;
 
   unreads.filter(message => !seenMessages.has(keyByMessage(message))).forEach((message) => {
     const {
       element, subject, sender, avatar,
     } = message;
     // do not show the same notification every time on start up
-    if (!startingUp) {
+    if (!checkUnreads.startingUp) {
       sendNotification({
         title: sender,
         body: subject,
@@ -92,6 +94,9 @@ function checkUnreads(period = 2000) {
     // mark message as seen
     seenMessages.set(keyByMessage(message), true);
   });
+  if (checkUnreads.startingUp) {
+    checkUnreads.startingUp = false;
+  }
 
   setTimeout(checkUnreads, period);
 }

--- a/app/renderer/unreads.js
+++ b/app/renderer/unreads.js
@@ -42,13 +42,6 @@ function extractSender(el, message) {
 }
 
 function getUnreadMessages() {
-  // not inside the inbox
-  const isInbox = $('.hA [title=Inbox]');
-
-  if (!isInbox) {
-    return [];
-  }
-
   return Array.from($$('.ss'))
     .map((message) => {
       const ancestorEl = ancestor(message, '.jS');
@@ -68,6 +61,13 @@ function getUnreadMessages() {
 }
 
 function checkUnreads(period = 2000) {
+  // skip if we're not inside the inbox
+  const isInbox = $('.hA [title=Inbox]');
+  if (!isInbox) {
+    setTimeout(checkUnreads, period);
+    return;
+  }
+
   if ( typeof checkUnreads.startingUp == 'undefined' ) {
     checkUnreads.startingUp = true;
   }

--- a/app/renderer/unreads.js
+++ b/app/renderer/unreads.js
@@ -76,12 +76,18 @@ function checkUnreads(period = 2000) {
 
   ipc.send('update-unreads-count', unreads.length);
 
-  unreads.filter(message => !seenMessages.has(keyByMessage(message))).forEach((message) => {
+  // mark all previously seen messages as false
+  for(const key of seenMessages.keys()) {
+    seenMessages.set(key, false);
+  }
+
+  unreads.forEach((message) => {
     const {
       element, subject, sender, avatar,
     } = message;
+    const key = keyByMessage(message);
     // do not show the same notification every time on start up
-    if (!checkUnreads.startingUp) {
+    if (!checkUnreads.startingUp && !seenMessages.has(key)) {
       sendNotification({
         title: sender,
         body: subject,
@@ -92,8 +98,16 @@ function checkUnreads(period = 2000) {
       });
     }
     // mark message as seen
-    seenMessages.set(keyByMessage(message), true);
+    seenMessages.set(key, true);
   });
+
+  // clean up old entries in seenMessages
+  for(const key of seenMessages.keys()) {
+    if (seenMessages.get(key) == false) {
+      seenMessages.delete(key);
+    }
+  }
+
   if (checkUnreads.startingUp) {
     checkUnreads.startingUp = false;
   }

--- a/app/renderer/unreads.js
+++ b/app/renderer/unreads.js
@@ -68,7 +68,7 @@ function checkUnreads(period = 2000) {
     return;
   }
 
-  if ( typeof checkUnreads.startingUp == 'undefined' ) {
+  if (typeof checkUnreads.startingUp === 'undefined') {
     checkUnreads.startingUp = true;
   }
 
@@ -77,9 +77,9 @@ function checkUnreads(period = 2000) {
   ipc.send('update-unreads-count', unreads.length);
 
   // mark all previously seen messages as false
-  for(const key of seenMessages.keys()) {
-    seenMessages.set(key, false);
-  }
+  seenMessages.forEach((value, key, map) => {
+    map.set(key, false);
+  });
 
   unreads.forEach((message) => {
     const {
@@ -102,11 +102,11 @@ function checkUnreads(period = 2000) {
   });
 
   // clean up old entries in seenMessages
-  for(const key of seenMessages.keys()) {
-    if (seenMessages.get(key) == false) {
-      seenMessages.delete(key);
+  seenMessages.forEach((value, key, map) => {
+    if (value === false) {
+      map.delete(key);
     }
-  }
+  });
 
   if (checkUnreads.startingUp) {
     checkUnreads.startingUp = false;


### PR DESCRIPTION
This fixes issue #65. 

The variable `seenMessages` is used to keep track of previously seen unread messages so that the user is not continuously notified about them. If this variable is allowed to grow indefinitely, some newly received message may look like an older one and a new mail notification will not be generated. See issue #65 for an example where this can happen.

The changes in this PR delete stale entries from `seenMessages` as the unread emails are read, keeping the contents of `seenMessages` up to date.