### PR TITLE
Improve detection of new messages in ongoing conversations

### DIFF
--- a/app/renderer/unreads.js
+++ b/app/renderer/unreads.js
@@ -5,9 +5,9 @@ const { ipcRenderer: ipc } = require('electron');
 
 const seenMessages = new Map();
 
-function keyByMessage({ subject, sender }) {
+function keyByMessage({ subject, sender, convlen }) {
   try {
-    return JSON.stringify({ subject, sender });
+    return JSON.stringify({ subject, sender, convlen });
   } catch (error) {
     console.error(error); // eslint-disable-line
     return undefined;
@@ -41,6 +41,14 @@ function extractSender(el, message) {
   return $('[email]', el).textContent;
 }
 
+function extractConversationLength(el) {
+    const len_span = $('span.qi', el);
+    if (len_span) {
+	return len_span.textContent;
+    }
+    return null;
+}
+
 function getUnreadMessages() {
   return Array.from($$('.ss'))
     .map((message) => {
@@ -55,6 +63,7 @@ function getUnreadMessages() {
         subject: extractSubject(ancestorEl),
         sender: extractSender(ancestorEl, message),
         avatar: extractAvatar(ancestorEl, message),
+        convlen: extractConversationLength(ancestorEl)
       };
     })
     .filter(Boolean);
@@ -83,7 +92,7 @@ function checkUnreads(period = 2000) {
 
   unreads.forEach((message) => {
     const {
-      element, subject, sender, avatar,
+      element, subject, sender, avatar, convlen
     } = message;
     const key = keyByMessage(message);
     // do not show the same notification every time on start up

--- a/app/renderer/unreads.js
+++ b/app/renderer/unreads.js
@@ -42,11 +42,11 @@ function extractSender(el, message) {
 }
 
 function extractConversationLength(el) {
-    const len_span = $('span.qi', el);
-    if (len_span) {
-	return len_span.textContent;
-    }
-    return null;
+  const lenSpan = $('span.qi', el);
+  if (lenSpan) {
+    return lenSpan.textContent;
+  }
+  return null;
 }
 
 function getUnreadMessages() {
@@ -63,7 +63,7 @@ function getUnreadMessages() {
         subject: extractSubject(ancestorEl),
         sender: extractSender(ancestorEl, message),
         avatar: extractAvatar(ancestorEl, message),
-        convlen: extractConversationLength(ancestorEl)
+        convlen: extractConversationLength(ancestorEl),
       };
     })
     .filter(Boolean);
@@ -92,7 +92,7 @@ function checkUnreads(period = 2000) {
 
   unreads.forEach((message) => {
     const {
-      element, subject, sender, avatar, convlen
+      element, subject, sender, avatar,
     } = message;
     const key = keyByMessage(message);
     // do not show the same notification every time on start up

--- a/app/renderer/unreads.js
+++ b/app/renderer/unreads.js
@@ -5,9 +5,9 @@ const { ipcRenderer: ipc } = require('electron');
 
 const seenMessages = new Map();
 
-function keyByMessage({ subject, sender, convlen }) {
+function keyByMessage({ subject, sender, conversationLength }) {
   try {
-    return JSON.stringify({ subject, sender, convlen });
+    return JSON.stringify({ subject, sender, conversationLength });
   } catch (error) {
     console.error(error); // eslint-disable-line
     return undefined;
@@ -43,10 +43,7 @@ function extractSender(el, message) {
 
 function extractConversationLength(el) {
   const lenSpan = $('span.qi', el);
-  if (lenSpan) {
-    return lenSpan.textContent;
-  }
-  return null;
+  return (lenSpan) ? lenSpan.textContent : null;
 }
 
 function getUnreadMessages() {
@@ -63,7 +60,7 @@ function getUnreadMessages() {
         subject: extractSubject(ancestorEl),
         sender: extractSender(ancestorEl, message),
         avatar: extractAvatar(ancestorEl, message),
-        convlen: extractConversationLength(ancestorEl),
+        conversationLength: extractConversationLength(ancestorEl),
       };
     })
     .filter(Boolean);


### PR DESCRIPTION
In a nutshell: add conversation length to message fingerprint.
The conversation length is displayed by Inbox as a number in parenthesis, like `(4)`. Using it in the message fingerprint allows us to reliably detect new unread emails in an ongoing conversation. For example:
- Alice sends me a new email -> I receive a new email notification. This new email is now stored in `seenMessages`.
- Before I have a chance to look at it, Alice replies to her own email
- This 2nd new email looks identical to the 1st already in `seenMessages` and no new email notification is generated.

In this situation the one thing that changes is the length of the conversation. By including the conversation length into the `seenMessage` fingerprint entry we can reliably detect any new emails in the conversation.