### PR TITLE
Publish Inboxer in the Snap Store

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,7 +97,8 @@
     "linux": {
       "target": [
         "AppImage",
-        "deb"
+        "deb",
+        "snap"
       ]
     },
     "win": {


### PR DESCRIPTION
Hey @jmarino I work on the Snapcraft team and would love to help get Inboxer published in the [Snap Store](https://snapcraft.io/store), which is the app store for Linux :smiley: This pull request adds a snap to the Linux builds.

Once published, you'll have direct control of the publishing life cycle, access to metrics for weekly active devices and users will get automatic updates. I see you're using Travis, here are the docs for publishing in the Snap Store.

  * https://docs.snapcraft.io/releasing-to-the-snap-store/6848
  * https://docs.travis-ci.com/user/deployment/snaps/

I'd love to feature Inboxer as an editors pick in the store and put together a social campaign to promote it. Is there any other help you need to get Inboxer published in the snap store?